### PR TITLE
Update library installation paths for Linux

### DIFF
--- a/tucamSupport/Makefile
+++ b/tucamSupport/Makefile
@@ -13,11 +13,11 @@ endif
 ifeq (linux-x86_64, $(findstring linux-x86_64, $(T_A)))
 SRC_DIRS += ../os/linux-x86_64
 ifndef UNIT_TESTING
-LIB_INSTALLS_Linux += ../os/linux-x86_64/libphxapi-x86_64.so
-LIB_INSTALLS_Linux += ../os/linux-x86_64/libTUCam.so
-LIB_INSTALLS_Linux += ../os/linux-x86_64/libTUCam.so.1
-LIB_INSTALLS_Linux += ../os/linux-x86_64/libTUCam.so.1.0
-LIB_INSTALLS_Linux += ../os/linux-x86_64/libTUCam.so.1.0.0
+LIB_INSTALLS_Linux += /usr/lib64/libphxapi-x86_64.so
+LIB_INSTALLS_Linux += /usr/lib64/libTUCam.so
+LIB_INSTALLS_Linux += /usr/lib64/libTUCam.so.1
+LIB_INSTALLS_Linux += /usr/lib64/libTUCam.so.1.0
+LIB_INSTALLS_Linux += /usr/lib64/libTUCam.so.1.0.0
 endif
 endif
 


### PR DESCRIPTION
Installing from the script given by Tucsen, it installs under `/usr/lib64`. Before, we assumed that the user copied these libraries to this repository under `tucamInclude/os/linux-x86_64/` which almost certainly won't be the case.

Using these absolute paths probably isn't great, but we can change to be more dynamic in the future when we need it.